### PR TITLE
Add session-based scoring and reset

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,9 +1,10 @@
-from flask import Flask, render_template, jsonify, request
+from flask import Flask, render_template, jsonify, request, session
 import json
 import random
 from pathlib import Path
 
 app = Flask(__name__)
+app.secret_key = 'secret-key'
 
 # Load vocabulary data
 DATA_FILE = Path('data/words.json')
@@ -12,7 +13,8 @@ with DATA_FILE.open(encoding='utf-8') as f:
 
 @app.route('/')
 def index():
-    return render_template('index.html')
+    score = session.get('score', 0)
+    return render_template('index.html', score=score)
 
 @app.route('/question')
 def question():
@@ -35,7 +37,16 @@ def answer():
     word = data.get('id')
     correct = word
     is_correct = (chosen == correct)
-    return jsonify({'correct': is_correct, 'answer': correct})
+    score = session.get('score', 0)
+    if is_correct:
+        score += 1
+    session['score'] = score
+    return jsonify({'correct': is_correct, 'answer': correct, 'score': score})
+
+@app.route('/reset', methods=['POST'])
+def reset_score():
+    session['score'] = 0
+    return jsonify({'score': 0})
 
 if __name__ == '__main__':
     app.run(debug=True)

--- a/templates/index.html
+++ b/templates/index.html
@@ -7,6 +7,8 @@
 </head>
 <body>
   <h1>영어 단어 퀴즈</h1>
+  <p id="score">점수: {{ score }}</p>
+  <button id="reset">점수 초기화</button>
   <div id="quiz">
     <p id="definition"></p>
     <form id="choices"></form>
@@ -47,8 +49,15 @@
           } else {
             $('#result').text('오답입니다. 정답: ' + res.answer);
           }
+          $('#score').text('점수: ' + res.score);
           loadQuestion();
         }
+      });
+    });
+
+    $('#reset').on('click', function() {
+      $.post('/reset', function(res) {
+        $('#score').text('점수: ' + res.score);
       });
     });
 


### PR DESCRIPTION
## Summary
- enable Flask session and add secret key
- track correct answers in the session
- show the current score on the page
- allow resetting the score

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6840f4d76480832ca317ff49b4725351