### PR TITLE
Add styling and score tracking

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,30 @@
+body {
+    font-family: Arial, sans-serif;
+    background-color: #f4f4f4;
+    color: #333;
+    margin: 20px;
+}
+
+#quiz {
+    background: #fff;
+    padding: 20px;
+    border-radius: 5px;
+    width: 300px;
+    margin: auto;
+    text-align: center;
+}
+
+button {
+    padding: 6px 12px;
+    margin-top: 10px;
+}
+
+#result {
+    font-weight: bold;
+    margin-top: 10px;
+    color: #007bff;
+}
+
+#scoreboard {
+    margin-bottom: 15px;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,18 +4,26 @@
   <meta charset="utf-8">
   <title>Vocabulary Quiz</title>
   <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+  <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
 </head>
 <body>
   <h1>영어 단어 퀴즈</h1>
   <div id="quiz">
+    <div id="scoreboard">점수: <span id="score">0</span></div>
     <p id="definition"></p>
     <form id="choices"></form>
     <button id="submit">제출</button>
+    <button id="next" type="button">다음 문제</button>
     <p id="result"></p>
   </div>
 
   <script>
     let currentId = null;
+    let score = 0;
+    function updateScore() {
+      $('#score').text(score);
+    }
+
     function loadQuestion() {
       $('#result').text('');
       $.getJSON('/question', function(data) {
@@ -44,12 +52,17 @@
         success: function(res) {
           if (res.correct) {
             $('#result').text('정답입니다!');
+            score += 1;
           } else {
             $('#result').text('오답입니다. 정답: ' + res.answer);
           }
-          loadQuestion();
+          updateScore();
         }
       });
+    });
+
+    $('#next').on('click', function() {
+      loadQuestion();
     });
 
     $(function() {

--- a/templates/index.html
+++ b/templates/index.html
@@ -57,6 +57,7 @@
             $('#result').text('오답입니다. 정답: ' + res.answer);
           }
           updateScore();
+          loadQuestion();
         }
       });
     });


### PR DESCRIPTION
## Summary
- style quiz app with a new static CSS
- show score and load styling in `index.html`
- add optional `Next Question` button and score tracking logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840f4d9b4f8832cab51f961def2e16e