### PR TITLE
Fix score display

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -21,7 +21,7 @@
 
   <script>
     let currentId = null;
-    let score = 0;
+    let score = {{ score }};
     function updateScore() {
       $('#score-value').text(score);
     }
@@ -54,10 +54,11 @@
         success: function(res) {
           if (res.correct) {
             $('#result').text('정답입니다!');
-            score += 1;
           } else {
             $('#result').text('오답입니다. 정답: ' + res.answer);
           }
+          score = res.score;
+          updateScore();
           loadQuestion();
         }
       });
@@ -66,11 +67,13 @@
 
     $('#reset').on('click', function() {
       $.post('/reset', function(res) {
-        $('#score-value').text(res.score);
+        score = res.score;
+        updateScore();
       });
     });
 
     $(function() {
+      updateScore();
       loadQuestion();
     });
   </script>


### PR DESCRIPTION
## Summary
- fix scoreboard updates after submitting an answer or resetting
- initialize score from the server so the page shows the right value

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840f96de8d4832ca96d51e4b4e020e1